### PR TITLE
Functionality for User-Defined "Start Menu" Icon

### DIFF
--- a/app/src/main/java/com/farmerbb/taskbar/fragment/AppearanceFragment.java
+++ b/app/src/main/java/com/farmerbb/taskbar/fragment/AppearanceFragment.java
@@ -193,7 +193,17 @@ public class AppearanceFragment extends SettingsFragment implements Preference.O
         }
 
         if (requestCode == 1001) {
-            Uri currFileURI = data.getData();
+            Uri currFileURI;
+            try {
+                currFileURI = data.getData();
+            }
+            catch (Exception ex) {
+                return;
+            }
+            if (currFileURI == null) {
+                return;
+            }
+
             final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getActivity());
             Boolean customStartImageBoolValue = prefs.getBoolean("app_drawer_icon_custom", true);
 

--- a/app/src/main/java/com/farmerbb/taskbar/fragment/AppearanceFragment.java
+++ b/app/src/main/java/com/farmerbb/taskbar/fragment/AppearanceFragment.java
@@ -192,14 +192,9 @@ public class AppearanceFragment extends SettingsFragment implements Preference.O
             U.restartTaskbar(getActivity());
         }
 
-        if (requestCode == 1001) {
-            Uri currFileURI;
-            try {
-                currFileURI = data.getData();
-            }
-            catch (Exception ex) {
-                return;
-            }
+        if (requestCode == 1001 && resultCode == Activity.RESULT_OK) {
+            Uri currFileURI = data.getData();
+
             if (currFileURI == null) {
                 return;
             }

--- a/app/src/main/java/com/farmerbb/taskbar/fragment/AppearanceFragment.java
+++ b/app/src/main/java/com/farmerbb/taskbar/fragment/AppearanceFragment.java
@@ -178,10 +178,10 @@ public class AppearanceFragment extends SettingsFragment implements Preference.O
         intent.addCategory(Intent.CATEGORY_OPENABLE);
 
         try {
-            startActivityForResult(Intent.createChooser(intent, "Select an Image File"), 1001);
+            startActivityForResult(Intent.createChooser(intent, getResources().getString(R.string.filepicker_select_an_image_file)), 1001);
         } catch (ActivityNotFoundException ex) {
             // Potentially direct the user to the Market with a Dialog
-            U.showToast(getActivity(), "Please install a File Manager.", 50);
+            U.showToast(getActivity(), getResources().getString(R.string.filepicker_install_file_manager), 50);
         }
     }
 

--- a/app/src/main/java/com/farmerbb/taskbar/fragment/AppearanceFragment.java
+++ b/app/src/main/java/com/farmerbb/taskbar/fragment/AppearanceFragment.java
@@ -15,7 +15,6 @@
 
 package com.farmerbb.taskbar.fragment;
 
-import android.Manifest;
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.ActivityNotFoundException;
@@ -23,13 +22,14 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.graphics.Color;
+import android.net.Uri;
 import android.os.Bundle;
+import android.preference.CheckBoxPreference;
 import android.preference.Preference;
-import android.provider.Settings;
+import android.preference.PreferenceManager;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
-import android.util.Log;
 import android.view.View;
 import android.widget.ScrollView;
 import android.widget.SeekBar;
@@ -60,9 +60,7 @@ public class AppearanceFragment extends SettingsFragment implements Preference.O
         findPreference("reset_colors").setOnPreferenceClickListener(this);
         findPreference("background_tint_pref").setOnPreferenceClickListener(this);
         findPreference("accent_color_pref").setOnPreferenceClickListener(this);
-        findPreference("app_drawer_icon_custom").setOnPreferenceClickListener(this);
         findPreference("app_drawer_icon_image").setOnPreferenceClickListener(this);
-
 
         bindPreferenceSummaryToValue(findPreference("theme"));
         bindPreferenceSummaryToValue(findPreference("invisible_button"));
@@ -166,11 +164,7 @@ public class AppearanceFragment extends SettingsFragment implements Preference.O
             case "accent_color_pref":
                 showColorPicker(ColorPickerType.ACCENT_COLOR);
                 break;
-            case "app_drawer_icon_custom":
-                //android.support.v4.app.ActivityCompat.requestPermissions(getActivity(), new String[]{Manifest.permission.READ_EXTERNAL_STORAGE}, 100);
-                break;
             case "app_drawer_icon_image":
-                //android.support.v4.app.ActivityCompat.requestPermissions(getActivity(), new String[]{Manifest.permission.READ_EXTERNAL_STORAGE}, 100);
                 showFileChooser();
                 break;
         }
@@ -185,7 +179,7 @@ public class AppearanceFragment extends SettingsFragment implements Preference.O
 
         try {
             startActivityForResult(Intent.createChooser(intent, "Select an Image File"), 1001);
-        } catch (android.content.ActivityNotFoundException ex) {
+        } catch (ActivityNotFoundException ex) {
             // Potentially direct the user to the Market with a Dialog
             U.showToast(getActivity(), "Please install a File Manager.", 50);
         }
@@ -199,12 +193,17 @@ public class AppearanceFragment extends SettingsFragment implements Preference.O
         }
 
         if (requestCode == 1001) {
-            android.net.Uri currFileURI = data.getData();
-            final SharedPreferences prefs = android.preference.PreferenceManager.getDefaultSharedPreferences(getActivity());
-            prefs.edit().putString("app_drawer_icon_image", currFileURI.toString()).commit();
-            if(prefs.getBoolean("app_drawer_icon_custom", true) == false) {
+            Uri currFileURI = data.getData();
+            final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getActivity());
+            Boolean customStartImageBoolValue = prefs.getBoolean("app_drawer_icon_custom", true);
+
+            if(customStartImageBoolValue == false) {
                 prefs.edit().putBoolean("app_drawer_icon_custom", true).commit();
+                ((CheckBoxPreference) findPreference("app_drawer_icon_custom")).setChecked(true);
             }
+
+            prefs.edit().putString("app_drawer_icon_image", currFileURI.toString()).commit();
+            bindPreferenceSummaryToValue(findPreference("app_drawer_icon_image"));
             U.restartTaskbar(getActivity());
         }
     }

--- a/app/src/main/java/com/farmerbb/taskbar/ui/TaskbarController.java
+++ b/app/src/main/java/com/farmerbb/taskbar/ui/TaskbarController.java
@@ -33,6 +33,7 @@ import android.content.pm.LauncherActivityInfo;
 import android.content.pm.LauncherApps;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
+import android.graphics.BitmapFactory;
 import android.graphics.Color;
 import android.graphics.Point;
 import android.graphics.Typeface;
@@ -292,6 +293,19 @@ public class TaskbarController implements Controller {
         } else {
             startButton.setImageDrawable(ContextCompat.getDrawable(context, R.drawable.all_apps_button_icon));
             padding = context.getResources().getDimensionPixelSize(R.dimen.app_drawer_icon_padding);
+        }
+
+        if(pref.getBoolean("app_drawer_icon_custom", true)) {
+            String strPath = "";
+            if (pref.getString("app_drawer_icon_image", "DEFAULT").isEmpty() == false) {
+                try {
+                    strPath = pref.getString("app_drawer_icon_image", "DEFAULT");
+                    startButton.setImageURI(android.net.Uri.parse(strPath));
+                    padding = context.getResources().getDimensionPixelSize(R.dimen.app_drawer_icon_padding);
+                } catch (Exception e) {
+                    U.showToast(this.context, "Error reading the custom image for the start menu. Try another file.", 500);
+                }
+            }
         }
 
         startButton.setPadding(padding, padding, padding, padding);

--- a/app/src/main/java/com/farmerbb/taskbar/ui/TaskbarController.java
+++ b/app/src/main/java/com/farmerbb/taskbar/ui/TaskbarController.java
@@ -303,7 +303,7 @@ public class TaskbarController implements Controller {
                     startButton.setImageURI(Uri.parse(strPath));
                     padding = context.getResources().getDimensionPixelSize(R.dimen.app_drawer_icon_padding);
                 } catch (Exception e) {
-                    U.showToast(this.context, "Error reading the custom image for the start menu. Try another file.", 500);
+                    U.showErrorDialog(this.context, this.context.getResources().getString(R.string.error_reading_custom_start_image));
                 }
             }
         }

--- a/app/src/main/java/com/farmerbb/taskbar/ui/TaskbarController.java
+++ b/app/src/main/java/com/farmerbb/taskbar/ui/TaskbarController.java
@@ -33,11 +33,11 @@ import android.content.pm.LauncherActivityInfo;
 import android.content.pm.LauncherApps;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
-import android.graphics.BitmapFactory;
 import android.graphics.Color;
 import android.graphics.Point;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
+import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
@@ -300,7 +300,7 @@ public class TaskbarController implements Controller {
             if (pref.getString("app_drawer_icon_image", "DEFAULT").isEmpty() == false) {
                 try {
                     strPath = pref.getString("app_drawer_icon_image", "DEFAULT");
-                    startButton.setImageURI(android.net.Uri.parse(strPath));
+                    startButton.setImageURI(Uri.parse(strPath));
                     padding = context.getResources().getDimensionPixelSize(R.dimen.app_drawer_icon_padding);
                 } catch (Exception e) {
                     U.showToast(this.context, "Error reading the custom image for the start menu. Try another file.", 500);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -205,6 +205,8 @@
     <string name="pref_description_use_mask">May reduce performance when an icon pack is set</string>
 
     <string name="pref_title_app_drawer_icon">Use Taskbar logo as start menu icon</string>
+    <string name="pref_title_app_drawer_icon_custom">Use custom image as start menu icon</string>
+    <string name="pref_title_app_drawer_icon_image">Custom Image Path</string>
     <string name="pref_title_app_drawer_icon_bliss">Use Bliss logo as start menu icon</string>
 
     <string name="already_blacklisted">%1$s can\'t be selected because it is on the hidden apps list</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -367,4 +367,8 @@
     <string name="force_activities_resizable">Force activities to be resizable</string>
     <string name="enable_freeform_windows">Enable freeform windows</string>
 
+    <string name="filepicker_select_an_image_file">Select an Image File</string>
+    <string name="filepicker_install_file_manager">"Please install a File Manager."</string>
+    <string name="error_reading_custom_start_image">Error reading the custom image for the start menu. Try another file.</string>
+
 </resources>

--- a/app/src/main/res/xml/pref_appearance.xml
+++ b/app/src/main/res/xml/pref_appearance.xml
@@ -48,6 +48,15 @@
         android:title="@string/pref_title_app_drawer_icon"/>
 
     <CheckBoxPreference
+        android:defaultValue="false"
+        android:key="app_drawer_icon_custom"
+        android:title="@string/pref_title_app_drawer_icon_custom"/>
+
+    <Preference
+        android:key="app_drawer_icon_image"
+        android:title="@string/pref_title_app_drawer_icon_image"/>
+
+    <CheckBoxPreference
         android:defaultValue="true"
         android:key="shortcut_icon"
         android:title="@string/pref_title_shortcut_icon"/>


### PR DESCRIPTION
This new functionality allows the user to choose an image from their system and apply it as the icon for the start menu. They can set the image within the Appearance settings activity to enable using a custom image as the start menu's icon and select the custom image to use.