### PR TITLE
Add variable to use Taskbar replace default Launchers in AOSP for Android.mk

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -32,6 +32,8 @@ LOCAL_SDK_VERSION := current
 
 LOCAL_PRIVILEGED_MODULE := true
 
+LOCAL_OVERRIDES_PACKAGES := Home Launcher2 Launcher3 Launcher3QuickStep
+
 LOCAL_AAPT_FLAGS := \
         --auto-add-overlay \
         --rename-manifest-package com.farmerbb.taskbar.androidx86 \

--- a/Android.mk
+++ b/Android.mk
@@ -32,7 +32,9 @@ LOCAL_SDK_VERSION := current
 
 LOCAL_PRIVILEGED_MODULE := true
 
+ifeq ($(EANBLE_TASKBAR_REPLACE),true)
 LOCAL_OVERRIDES_PACKAGES := Home Launcher2 Launcher3 Launcher3QuickStep
+endif
 
 LOCAL_AAPT_FLAGS := \
         --auto-add-overlay \


### PR DESCRIPTION
When AOSP wants to integrate Taskbar as default Launcher, we can use Taskbar to override other Launchers in AOSP to make sure the system will build the Taskbar only. Also we can remove other Launchers from build system, but it needs to modify the build system to support remove packages with variable, such as add new variable `REMOVE_PRODUCT_PACKAGES`, or remove them from `PRODUCT_PACKAGES` in `build/make/target/product/core.mk`. All methods need user to change other code in build system. With the added variable `ENABLE_TASKBAR_REPLACE`, user only should add `ENABLE_TASKBAR_REPLACE := true` to this device makefile. The default behaviour is as the normal, doesn't apply overriding, it will not affect the user has integrated Taskbar to AOSP or other Android-inherited system.