### PR TITLE
Extract HIDE_TASKBAR string to TaskbarIntent.ACTION_HIDE_TASKBAR

### DIFF
--- a/app/src/main/java/com/farmerbb/taskbar/activity/AbstractSelectAppActivity.java
+++ b/app/src/main/java/com/farmerbb/taskbar/activity/AbstractSelectAppActivity.java
@@ -35,6 +35,7 @@ import android.widget.ProgressBar;
 
 import com.farmerbb.taskbar.R;
 import com.farmerbb.taskbar.adapter.DesktopIconAppListAdapter;
+import com.farmerbb.taskbar.content.TaskbarIntent;
 import com.farmerbb.taskbar.util.AppEntry;
 import com.farmerbb.taskbar.util.IconCache;
 import com.farmerbb.taskbar.util.U;
@@ -74,8 +75,11 @@ public abstract class AbstractSelectAppActivity extends AppCompatActivity {
         SharedPreferences pref = U.getSharedPreferences(this);
         isCollapsed = !pref.getBoolean("collapsed", false);
 
-        if(!isCollapsed)
-            LocalBroadcastManager.getInstance(this).sendBroadcast(new Intent("com.farmerbb.taskbar.HIDE_TASKBAR"));
+        if(!isCollapsed) {
+            LocalBroadcastManager
+                    .getInstance(this)
+                    .sendBroadcast(new Intent(TaskbarIntent.ACTION_HIDE_TASKBAR));
+        }
 
         progressBar = findViewById(R.id.progress_bar);
         appList = findViewById(R.id.list);

--- a/app/src/main/java/com/farmerbb/taskbar/activity/ContextMenuActivity.java
+++ b/app/src/main/java/com/farmerbb/taskbar/activity/ContextMenuActivity.java
@@ -47,6 +47,7 @@ import com.farmerbb.taskbar.BuildConfig;
 import com.farmerbb.taskbar.R;
 import com.farmerbb.taskbar.activity.dark.DesktopIconSelectAppActivityDark;
 import com.farmerbb.taskbar.activity.dark.SelectAppActivityDark;
+import com.farmerbb.taskbar.content.TaskbarIntent;
 import com.farmerbb.taskbar.util.AppEntry;
 import com.farmerbb.taskbar.util.ApplicationType;
 import com.farmerbb.taskbar.util.DesktopIconInfo;
@@ -778,8 +779,11 @@ public class ContextMenuActivity extends PreferenceActivity implements Preferenc
             else {
                 LocalBroadcastManager.getInstance(this).sendBroadcast(new Intent("com.farmerbb.taskbar.RESET_START_MENU"));
 
-                if(shouldHideTaskbar && U.shouldCollapse(this, true))
-                    LocalBroadcastManager.getInstance(this).sendBroadcast(new Intent("com.farmerbb.taskbar.HIDE_TASKBAR"));
+                if(shouldHideTaskbar && U.shouldCollapse(this, true)) {
+                    LocalBroadcastManager
+                            .getInstance(this)
+                            .sendBroadcast(new Intent(TaskbarIntent.ACTION_HIDE_TASKBAR));
+                }
             }
         }
 

--- a/app/src/main/java/com/farmerbb/taskbar/activity/DashboardActivity.java
+++ b/app/src/main/java/com/farmerbb/taskbar/activity/DashboardActivity.java
@@ -38,6 +38,7 @@ import android.widget.FrameLayout;
 import android.widget.LinearLayout;
 
 import com.farmerbb.taskbar.R;
+import com.farmerbb.taskbar.content.TaskbarIntent;
 import com.farmerbb.taskbar.util.DashboardHelper;
 import com.farmerbb.taskbar.util.DisplayInfo;
 import com.farmerbb.taskbar.util.LauncherHelper;
@@ -174,10 +175,15 @@ public class DashboardActivity extends Activity {
 
         if(shouldFinish) {
             if(shouldCollapse) {
-                if(U.shouldCollapse(this, true))
-                    LocalBroadcastManager.getInstance(this).sendBroadcast(new Intent("com.farmerbb.taskbar.HIDE_TASKBAR"));
-                else
-                    LocalBroadcastManager.getInstance(this).sendBroadcast(new Intent("com.farmerbb.taskbar.HIDE_START_MENU"));
+                if(U.shouldCollapse(this, true)) {
+                    LocalBroadcastManager
+                            .getInstance(this)
+                            .sendBroadcast(new Intent(TaskbarIntent.ACTION_HIDE_TASKBAR));
+                } else {
+                    LocalBroadcastManager
+                            .getInstance(this)
+                            .sendBroadcast(new Intent("com.farmerbb.taskbar.HIDE_START_MENU"));
+                }
             }
 
             contextMenuFix = false;

--- a/app/src/main/java/com/farmerbb/taskbar/activity/InvisibleActivityFreeform.java
+++ b/app/src/main/java/com/farmerbb/taskbar/activity/InvisibleActivityFreeform.java
@@ -31,6 +31,7 @@ import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import android.view.WindowManager;
 
 import com.farmerbb.taskbar.activity.dark.InvisibleActivityAltDark;
+import com.farmerbb.taskbar.content.TaskbarIntent;
 import com.farmerbb.taskbar.service.DashboardService;
 import com.farmerbb.taskbar.service.NotificationService;
 import com.farmerbb.taskbar.service.StartMenuService;
@@ -266,10 +267,15 @@ public class InvisibleActivityFreeform extends Activity {
     private void possiblyHideTaskbar() {
         if(!doNotHide) {
             new Handler().postDelayed(() -> {
-                if(U.shouldCollapse(this, false) && !LauncherHelper.getInstance().isOnHomeScreen())
-                    LocalBroadcastManager.getInstance(this).sendBroadcast(new Intent("com.farmerbb.taskbar.HIDE_TASKBAR"));
-                else
-                    LocalBroadcastManager.getInstance(this).sendBroadcast(new Intent("com.farmerbb.taskbar.HIDE_START_MENU"));
+                if(U.shouldCollapse(this, false) && !LauncherHelper.getInstance().isOnHomeScreen()) {
+                    LocalBroadcastManager
+                            .getInstance(this)
+                            .sendBroadcast(new Intent(TaskbarIntent.ACTION_HIDE_TASKBAR));
+                } else {
+                    LocalBroadcastManager
+                            .getInstance(this)
+                            .sendBroadcast(new Intent("com.farmerbb.taskbar.HIDE_START_MENU"));
+                }
             }, 100);
         }
     }

--- a/app/src/main/java/com/farmerbb/taskbar/activity/SelectAppActivity.java
+++ b/app/src/main/java/com/farmerbb/taskbar/activity/SelectAppActivity.java
@@ -26,6 +26,8 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.UserHandle;
 import android.os.UserManager;
+
+import com.farmerbb.taskbar.content.TaskbarIntent;
 import com.google.android.material.tabs.TabLayout;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
@@ -112,8 +114,11 @@ public class SelectAppActivity extends AppCompatActivity {
             SharedPreferences pref = U.getSharedPreferences(this);
             isCollapsed = !pref.getBoolean("collapsed", false);
 
-            if(!isCollapsed)
-                LocalBroadcastManager.getInstance(this).sendBroadcast(new Intent("com.farmerbb.taskbar.HIDE_TASKBAR"));
+            if(!isCollapsed) {
+                LocalBroadcastManager
+                        .getInstance(this)
+                        .sendBroadcast(new Intent(TaskbarIntent.ACTION_HIDE_TASKBAR));
+            }
 
             progressBar = findViewById(R.id.progress_bar);
             appListGenerator = new AppListGenerator();

--- a/app/src/main/java/com/farmerbb/taskbar/content/TaskbarIntent.java
+++ b/app/src/main/java/com/farmerbb/taskbar/content/TaskbarIntent.java
@@ -1,0 +1,5 @@
+package com.farmerbb.taskbar.content;
+
+public class TaskbarIntent {
+    public static final String ACTION_HIDE_TASKBAR = "com.farmerbb.taskbar.HIDE_TASKBAR";
+}

--- a/app/src/main/java/com/farmerbb/taskbar/ui/StartMenuController.java
+++ b/app/src/main/java/com/farmerbb/taskbar/ui/StartMenuController.java
@@ -60,6 +60,7 @@ import com.farmerbb.taskbar.R;
 import com.farmerbb.taskbar.activity.InvisibleActivity;
 import com.farmerbb.taskbar.activity.InvisibleActivityAlt;
 import com.farmerbb.taskbar.adapter.StartMenuAdapter;
+import com.farmerbb.taskbar.content.TaskbarIntent;
 import com.farmerbb.taskbar.util.AppEntry;
 import com.farmerbb.taskbar.util.Blacklist;
 import com.farmerbb.taskbar.util.FreeformHackHelper;
@@ -304,11 +305,15 @@ public class StartMenuController implements UIController {
                                 LinearLayout layout = view.findViewById(R.id.entry);
                                 layout.performClick();
                             } else {
-                                if(U.shouldCollapse(context, true))
-                                    LocalBroadcastManager.getInstance(context).sendBroadcast(new Intent("com.farmerbb.taskbar.HIDE_TASKBAR"));
-                                else
-                                    LocalBroadcastManager.getInstance(context).sendBroadcast(new Intent("com.farmerbb.taskbar.HIDE_START_MENU"));
-
+                                if(U.shouldCollapse(context, true)) {
+                                    LocalBroadcastManager
+                                            .getInstance(context)
+                                            .sendBroadcast(new Intent(TaskbarIntent.ACTION_HIDE_TASKBAR));
+                                } else {
+                                    LocalBroadcastManager
+                                            .getInstance(context)
+                                            .sendBroadcast(new Intent("com.farmerbb.taskbar.HIDE_START_MENU"));
+                                }
                                 Intent intent;
 
                                 if(Patterns.WEB_URL.matcher(query).matches()) {

--- a/app/src/main/java/com/farmerbb/taskbar/ui/TaskbarController.java
+++ b/app/src/main/java/com/farmerbb/taskbar/ui/TaskbarController.java
@@ -95,6 +95,7 @@ import com.farmerbb.taskbar.R;
 import com.farmerbb.taskbar.activity.HomeActivity;
 import com.farmerbb.taskbar.activity.InvisibleActivityFreeform;
 import com.farmerbb.taskbar.activity.SecondaryHomeActivity;
+import com.farmerbb.taskbar.content.TaskbarIntent;
 import com.farmerbb.taskbar.util.AppEntry;
 import com.farmerbb.taskbar.util.DisplayInfo;
 import com.farmerbb.taskbar.util.FreeformHackHelper;
@@ -639,7 +640,7 @@ public class TaskbarController implements UIController {
         lbm.unregisterReceiver(startMenuDisappearReceiver);
 
         lbm.registerReceiver(showReceiver, new IntentFilter("com.farmerbb.taskbar.SHOW_TASKBAR"));
-        lbm.registerReceiver(hideReceiver, new IntentFilter("com.farmerbb.taskbar.HIDE_TASKBAR"));
+        lbm.registerReceiver(hideReceiver, new IntentFilter(TaskbarIntent.ACTION_HIDE_TASKBAR));
         lbm.registerReceiver(tempShowReceiver, new IntentFilter("com.farmerbb.taskbar.TEMP_SHOW_TASKBAR"));
         lbm.registerReceiver(tempHideReceiver, new IntentFilter("com.farmerbb.taskbar.TEMP_HIDE_TASKBAR"));
         lbm.registerReceiver(startMenuAppearReceiver, new IntentFilter("com.farmerbb.taskbar.START_MENU_APPEARING"));

--- a/app/src/main/java/com/farmerbb/taskbar/util/U.java
+++ b/app/src/main/java/com/farmerbb/taskbar/util/U.java
@@ -69,6 +69,7 @@ import com.farmerbb.taskbar.activity.InvisibleActivityFreeform;
 import com.farmerbb.taskbar.activity.MainActivity;
 import com.farmerbb.taskbar.activity.TouchAbsorberActivity;
 import com.farmerbb.taskbar.activity.dark.ContextMenuActivityDark;
+import com.farmerbb.taskbar.content.TaskbarIntent;
 import com.farmerbb.taskbar.service.DashboardService;
 import com.farmerbb.taskbar.service.NotificationService;
 import com.farmerbb.taskbar.service.PowerMenuService;
@@ -468,10 +469,15 @@ public class U {
                 launchShortcut(context, shortcut, bundle, onError);
         });
 
-        if(shouldCollapse(context, true))
-            LocalBroadcastManager.getInstance(context).sendBroadcast(new Intent("com.farmerbb.taskbar.HIDE_TASKBAR"));
-        else
-            LocalBroadcastManager.getInstance(context).sendBroadcast(new Intent("com.farmerbb.taskbar.HIDE_START_MENU"));
+        if(shouldCollapse(context, true)) {
+            LocalBroadcastManager
+                    .getInstance(context)
+                    .sendBroadcast(new Intent(TaskbarIntent.ACTION_HIDE_TASKBAR));
+        } else {
+            LocalBroadcastManager
+                    .getInstance(context)
+                    .sendBroadcast(new Intent("com.farmerbb.taskbar.HIDE_START_MENU"));
+        }
     }
 
     private static Bundle launchMode1(Context context, ApplicationType type, View view, int factor) {

--- a/app/src/playstore/java/com/farmerbb/taskbar/receiver/TaskerActionReceiver.java
+++ b/app/src/playstore/java/com/farmerbb/taskbar/receiver/TaskerActionReceiver.java
@@ -21,6 +21,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
+import com.farmerbb.taskbar.content.TaskbarIntent;
 import com.farmerbb.taskbar.util.BundleScrubber;
 import com.farmerbb.taskbar.util.PluginBundleManager;
 import com.farmerbb.taskbar.util.U;
@@ -62,7 +63,7 @@ public final class TaskerActionReceiver extends BroadcastReceiver {
             case "show_taskbar":
                 return new Intent("com.farmerbb.taskbar.SHOW_TASKBAR");
             case "hide_taskbar":
-                return new Intent("com.farmerbb.taskbar.HIDE_TASKBAR");
+                return new Intent(TaskbarIntent.ACTION_HIDE_TASKBAR);
             case "toggle_start_menu":
                 return new Intent("com.farmerbb.taskbar.TOGGLE_START_MENU");
             case "toggle_dashboard":


### PR DESCRIPTION
String com.farmerbb.taskbar.HIDE_TASKBAR is used on many place,
so we should extract it to a constant field to simply the usage.
Because this string is used to Intent, we create a class called
TaskbarIntent, that is similar to system's Intent to store
constant fields used by Intent.

@farmerbb I don't know whether you need such like changes, so I just 
change one string only in this pr to discuss with. Thanks.