### PR TITLE
Fix gradle warning of deprecated API for jacoco

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -149,9 +149,9 @@ task jacocoTestReport(type: JacocoReport, dependsOn: ['testFreeDebugUnitTest']) 
     def debugTree = fileTree(dir: "$buildDir/intermediates/javac/freeDebug/classes", excludes: fileFilter)
     def mainSrc = "${project.projectDir}/src/main/java"
 
-    sourceDirectories = files([mainSrc])
-    classDirectories = files([debugTree])
-    executionData = files("$buildDir/jacoco/testFreeDebugUnitTest.exec")
+    sourceDirectories.from = [mainSrc]
+    classDirectories.from = [debugTree]
+    executionData.from = "$buildDir/jacoco/testFreeDebugUnitTest.exec"
 
     doLast {
         println("Test report link: file://$buildDir/reports/jacoco/jacocoTestReport/html/index.html")


### PR DESCRIPTION
See [Gradle 6.0 deprecation warning for JacocoReport configuration](https://stackoverflow.com/questions/56181089/gradle-6-0-deprecation-warning-for-jacocoreport-configuration/56181389)

Test: run `./gradlew jacocoTestReport`, and it generates the correct report html.