### PR TITLE
Split TasbarController large methods part01

### DIFF
--- a/app/src/main/java/com/farmerbb/taskbar/ui/TaskbarController.java
+++ b/app/src/main/java/com/farmerbb/taskbar/ui/TaskbarController.java
@@ -239,48 +239,10 @@ public class TaskbarController extends UIController {
         );
 
         // Determine where to show the taskbar on screen
-        switch(TaskbarPosition.getTaskbarPosition(context)) {
-            case POSITION_BOTTOM_LEFT:
-                layoutId = R.layout.tb_taskbar_left;
-                params.gravity = Gravity.BOTTOM | Gravity.LEFT;
-                positionIsVertical = false;
-                break;
-            case POSITION_BOTTOM_VERTICAL_LEFT:
-                layoutId = R.layout.tb_taskbar_vertical;
-                params.gravity = Gravity.BOTTOM | Gravity.LEFT;
-                positionIsVertical = true;
-                break;
-            case POSITION_BOTTOM_RIGHT:
-                layoutId = R.layout.tb_taskbar_right;
-                params.gravity = Gravity.BOTTOM | Gravity.RIGHT;
-                positionIsVertical = false;
-                break;
-            case POSITION_BOTTOM_VERTICAL_RIGHT:
-                layoutId = R.layout.tb_taskbar_vertical;
-                params.gravity = Gravity.BOTTOM | Gravity.RIGHT;
-                positionIsVertical = true;
-                break;
-            case POSITION_TOP_LEFT:
-                layoutId = R.layout.tb_taskbar_left;
-                params.gravity = Gravity.TOP | Gravity.LEFT;
-                positionIsVertical = false;
-                break;
-            case POSITION_TOP_VERTICAL_LEFT:
-                layoutId = R.layout.tb_taskbar_top_vertical;
-                params.gravity = Gravity.TOP | Gravity.LEFT;
-                positionIsVertical = true;
-                break;
-            case POSITION_TOP_RIGHT:
-                layoutId = R.layout.tb_taskbar_right;
-                params.gravity = Gravity.TOP | Gravity.RIGHT;
-                positionIsVertical = false;
-                break;
-            case POSITION_TOP_VERTICAL_RIGHT:
-                layoutId = R.layout.tb_taskbar_top_vertical;
-                params.gravity = Gravity.TOP | Gravity.RIGHT;
-                positionIsVertical = true;
-                break;
-        }
+        String taskbarPosition = TaskbarPosition.getTaskbarPosition(context);
+        params.gravity = getTaskbarGravity(taskbarPosition);
+        layoutId = getTaskbarLayoutId(taskbarPosition);
+        positionIsVertical = TaskbarPosition.isVertical(taskbarPosition);
 
         // Initialize views
         SharedPreferences pref = U.getSharedPreferences(context);
@@ -573,6 +535,52 @@ public class TaskbarController extends UIController {
         host.addView(layout, params);
 
         isFirstStart = false;
+    }
+
+    public int getTaskbarGravity(String taskbarPosition) {
+        int gravity = Gravity.BOTTOM | Gravity.LEFT;
+        switch(taskbarPosition) {
+            case POSITION_BOTTOM_LEFT:
+            case POSITION_BOTTOM_VERTICAL_LEFT:
+                gravity = Gravity.BOTTOM | Gravity.LEFT;
+                break;
+            case POSITION_BOTTOM_RIGHT:
+            case POSITION_BOTTOM_VERTICAL_RIGHT:
+                gravity = Gravity.BOTTOM | Gravity.RIGHT;
+                break;
+            case POSITION_TOP_LEFT:
+            case POSITION_TOP_VERTICAL_LEFT:
+                gravity = Gravity.TOP | Gravity.LEFT;
+                break;
+            case POSITION_TOP_RIGHT:
+            case POSITION_TOP_VERTICAL_RIGHT:
+                gravity = Gravity.TOP | Gravity.RIGHT;
+                break;
+        }
+        return gravity;
+    }
+
+    private int getTaskbarLayoutId(String taskbarPosition) {
+        int layoutId = R.layout.tb_taskbar_left;
+        switch(taskbarPosition) {
+            case POSITION_BOTTOM_LEFT:
+            case POSITION_TOP_LEFT:
+                layoutId = R.layout.tb_taskbar_left;
+                break;
+            case POSITION_BOTTOM_VERTICAL_LEFT:
+            case POSITION_BOTTOM_VERTICAL_RIGHT:
+                layoutId = R.layout.tb_taskbar_vertical;
+                break;
+            case POSITION_BOTTOM_RIGHT:
+            case POSITION_TOP_RIGHT:
+                layoutId = R.layout.tb_taskbar_right;
+                break;
+            case POSITION_TOP_VERTICAL_LEFT:
+            case POSITION_TOP_VERTICAL_RIGHT:
+                layoutId = R.layout.tb_taskbar_top_vertical;
+                break;
+        }
+        return layoutId;
     }
 
     private void drawStartButton(Context context, ImageView startButton, SharedPreferences pref, int accentColor) {

--- a/app/src/main/java/com/farmerbb/taskbar/ui/TaskbarController.java
+++ b/app/src/main/java/com/farmerbb/taskbar/ui/TaskbarController.java
@@ -304,66 +304,7 @@ public class TaskbarController extends UIController {
         space.setOnClickListener(v -> toggleTaskbar(true));
 
         startButton = layout.findViewById(R.id.start_button);
-        int padding = 0;
-
-        switch(pref.getString(PREF_START_BUTTON_IMAGE, U.getDefaultStartButtonImage(context))) {
-            case "default":
-                startButton.setImageDrawable(ContextCompat.getDrawable(context, R.drawable.tb_all_apps_button_icon));
-                padding = context.getResources().getDimensionPixelSize(R.dimen.tb_app_drawer_icon_padding);
-                break;
-            case "app_logo":
-                Drawable drawable;
-
-                if(U.isBlissOs(context)) {
-                    drawable = ContextCompat.getDrawable(context, R.drawable.tb_bliss);
-                    drawable.setTint(accentColor);
-                } else {
-                    LauncherApps launcherApps = (LauncherApps) context.getSystemService(Context.LAUNCHER_APPS_SERVICE);
-                    LauncherActivityInfo info = launcherApps.getActivityList(context.getPackageName(), Process.myUserHandle()).get(0);
-                    drawable = IconCache.getInstance(context).getIcon(context, context.getPackageManager(), info);
-                }
-
-                startButton.setImageDrawable(drawable);
-                padding = context.getResources().getDimensionPixelSize(R.dimen.tb_app_drawer_icon_padding_alt);
-                break;
-            case "custom":
-                File file = new File(context.getFilesDir() + "/tb_images", "custom_image");
-                if(file.exists()) {
-                    Handler handler = new Handler();
-                    new Thread(() -> {
-                        Bitmap bitmap = BitmapFactory.decodeFile(file.getPath());
-                        handler.post(() -> {
-                            if(bitmap != null) {
-                                BitmapDrawable bitmapDrawable = new BitmapDrawable(context.getResources(), bitmap);
-                                bitmapDrawable.setFilterBitmap(bitmap.getWidth() * bitmap.getHeight() > 2000);
-                                startButton.setImageDrawable(bitmapDrawable);
-                            } else {
-                                U.showToastLong(context, R.string.tb_error_reading_custom_start_image);
-                                startButton.setImageDrawable(ContextCompat.getDrawable(context, R.drawable.tb_all_apps_button_icon));
-                            }
-                        });
-                    }).start();
-                } else
-                    startButton.setImageDrawable(ContextCompat.getDrawable(context, R.drawable.tb_all_apps_button_icon));
-
-                padding = context.getResources().getDimensionPixelSize(R.dimen.tb_app_drawer_icon_padding);
-                break;
-        }
-
-        startButton.setPadding(padding, padding, padding, padding);
-        startButton.setOnClickListener(ocl);
-        startButton.setOnLongClickListener(view -> {
-            openContextMenu();
-            return true;
-        });
-
-        startButton.setOnGenericMotionListener((view, motionEvent) -> {
-            if(motionEvent.getAction() == MotionEvent.ACTION_BUTTON_PRESS
-                    && motionEvent.getButtonState() == MotionEvent.BUTTON_SECONDARY)
-                openContextMenu();
-
-            return false;
-        });
+        drawStartButton(context, startButton, pref, accentColor);
 
         refreshInterval = (int) (Float.parseFloat(pref.getString(PREF_REFRESH_FREQUENCY, "1")) * 1000);
         if(refreshInterval == 0)
@@ -632,6 +573,69 @@ public class TaskbarController extends UIController {
         host.addView(layout, params);
 
         isFirstStart = false;
+    }
+
+    private void drawStartButton(Context context, ImageView startButton, SharedPreferences pref, int accentColor) {
+        int padding = 0;
+
+        switch(pref.getString(PREF_START_BUTTON_IMAGE, U.getDefaultStartButtonImage(context))) {
+            case "default":
+                startButton.setImageDrawable(ContextCompat.getDrawable(context, R.drawable.tb_all_apps_button_icon));
+                padding = context.getResources().getDimensionPixelSize(R.dimen.tb_app_drawer_icon_padding);
+                break;
+            case "app_logo":
+                Drawable drawable;
+
+                if(U.isBlissOs(context)) {
+                    drawable = ContextCompat.getDrawable(context, R.drawable.tb_bliss);
+                    drawable.setTint(accentColor);
+                } else {
+                    LauncherApps launcherApps = (LauncherApps) context.getSystemService(Context.LAUNCHER_APPS_SERVICE);
+                    LauncherActivityInfo info = launcherApps.getActivityList(context.getPackageName(), Process.myUserHandle()).get(0);
+                    drawable = IconCache.getInstance(context).getIcon(context, context.getPackageManager(), info);
+                }
+
+                startButton.setImageDrawable(drawable);
+                padding = context.getResources().getDimensionPixelSize(R.dimen.tb_app_drawer_icon_padding_alt);
+                break;
+            case "custom":
+                File file = new File(context.getFilesDir() + "/tb_images", "custom_image");
+                if(file.exists()) {
+                    Handler handler = new Handler();
+                    new Thread(() -> {
+                        Bitmap bitmap = BitmapFactory.decodeFile(file.getPath());
+                        handler.post(() -> {
+                            if(bitmap != null) {
+                                BitmapDrawable bitmapDrawable = new BitmapDrawable(context.getResources(), bitmap);
+                                bitmapDrawable.setFilterBitmap(bitmap.getWidth() * bitmap.getHeight() > 2000);
+                                startButton.setImageDrawable(bitmapDrawable);
+                            } else {
+                                U.showToastLong(context, R.string.tb_error_reading_custom_start_image);
+                                startButton.setImageDrawable(ContextCompat.getDrawable(context, R.drawable.tb_all_apps_button_icon));
+                            }
+                        });
+                    }).start();
+                } else
+                    startButton.setImageDrawable(ContextCompat.getDrawable(context, R.drawable.tb_all_apps_button_icon));
+
+                padding = context.getResources().getDimensionPixelSize(R.dimen.tb_app_drawer_icon_padding);
+                break;
+        }
+
+        startButton.setPadding(padding, padding, padding, padding);
+        startButton.setOnClickListener(ocl);
+        startButton.setOnLongClickListener(view -> {
+            openContextMenu();
+            return true;
+        });
+
+        startButton.setOnGenericMotionListener((view, motionEvent) -> {
+            if(motionEvent.getAction() == MotionEvent.ACTION_BUTTON_PRESS
+                    && motionEvent.getButtonState() == MotionEvent.BUTTON_SECONDARY)
+                openContextMenu();
+
+            return false;
+        });
     }
 
     private void startRefreshingRecents() {

--- a/app/src/test/java/com/farmerbb/taskbar/ui/TaskbarControllerTest.java
+++ b/app/src/test/java/com/farmerbb/taskbar/ui/TaskbarControllerTest.java
@@ -3,6 +3,7 @@ package com.farmerbb.taskbar.ui;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.graphics.Color;
+import android.view.Gravity;
 import android.widget.ImageView;
 
 import androidx.test.core.app.ApplicationProvider;
@@ -10,6 +11,7 @@ import androidx.test.core.app.ApplicationProvider;
 import com.farmerbb.taskbar.R;
 import com.farmerbb.taskbar.util.U;
 
+import org.bouncycastle.jcajce.provider.symmetric.Grain128;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -23,6 +25,14 @@ import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.android.controller.ServiceController;
 
+import static com.farmerbb.taskbar.util.Constants.POSITION_BOTTOM_LEFT;
+import static com.farmerbb.taskbar.util.Constants.POSITION_BOTTOM_RIGHT;
+import static com.farmerbb.taskbar.util.Constants.POSITION_BOTTOM_VERTICAL_LEFT;
+import static com.farmerbb.taskbar.util.Constants.POSITION_BOTTOM_VERTICAL_RIGHT;
+import static com.farmerbb.taskbar.util.Constants.POSITION_TOP_LEFT;
+import static com.farmerbb.taskbar.util.Constants.POSITION_TOP_RIGHT;
+import static com.farmerbb.taskbar.util.Constants.POSITION_TOP_VERTICAL_LEFT;
+import static com.farmerbb.taskbar.util.Constants.POSITION_TOP_VERTICAL_RIGHT;
 import static com.farmerbb.taskbar.util.Constants.PREF_START_BUTTON_IMAGE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -89,6 +99,102 @@ public class TaskbarControllerTest {
         prefs.edit().putString(PREF_START_BUTTON_IMAGE, "non-support").apply();
         callDrawStartButton(context, startButton, prefs);
         checkStartButtonPadding(0, startButton);
+    }
+
+    @Test
+    public void testGetTaskbarGravity() {
+        assertEquals(
+                Gravity.BOTTOM | Gravity.LEFT,
+                callGetTaskbarGravity(POSITION_BOTTOM_LEFT)
+        );
+        assertEquals(
+                Gravity.BOTTOM | Gravity.LEFT,
+                callGetTaskbarGravity(POSITION_BOTTOM_VERTICAL_LEFT)
+        );
+        assertEquals(
+                Gravity.BOTTOM | Gravity.RIGHT,
+                callGetTaskbarGravity(POSITION_BOTTOM_RIGHT)
+        );
+        assertEquals(
+                Gravity.BOTTOM | Gravity.RIGHT,
+                callGetTaskbarGravity(POSITION_BOTTOM_VERTICAL_RIGHT)
+        );
+        assertEquals(
+                Gravity.TOP | Gravity.LEFT,
+                callGetTaskbarGravity(POSITION_TOP_LEFT)
+        );
+        assertEquals(
+                Gravity.TOP | Gravity.LEFT,
+                callGetTaskbarGravity(POSITION_TOP_VERTICAL_LEFT)
+        );
+        assertEquals(
+                Gravity.TOP | Gravity.RIGHT,
+                callGetTaskbarGravity(POSITION_TOP_RIGHT)
+        );
+        assertEquals(
+                Gravity.TOP | Gravity.RIGHT,
+                callGetTaskbarGravity(POSITION_TOP_VERTICAL_RIGHT)
+        );
+        assertEquals(
+                Gravity.BOTTOM | Gravity.LEFT,
+                callGetTaskbarGravity("unsupported")
+        );
+    }
+
+    @Test
+    public void testGetTaskbarLayoutId() {
+        assertEquals(
+                R.layout.tb_taskbar_left,
+                callGetTaskbarLayoutId(POSITION_BOTTOM_LEFT)
+        );
+        assertEquals(
+                R.layout.tb_taskbar_vertical,
+                callGetTaskbarLayoutId(POSITION_BOTTOM_VERTICAL_LEFT)
+        );
+        assertEquals(
+                R.layout.tb_taskbar_right,
+                callGetTaskbarLayoutId(POSITION_BOTTOM_RIGHT)
+        );
+        assertEquals(
+                R.layout.tb_taskbar_vertical,
+                callGetTaskbarLayoutId(POSITION_BOTTOM_VERTICAL_RIGHT)
+        );
+        assertEquals(
+                R.layout.tb_taskbar_left,
+                callGetTaskbarLayoutId(POSITION_TOP_LEFT)
+        );
+        assertEquals(
+                R.layout.tb_taskbar_top_vertical,
+                callGetTaskbarLayoutId(POSITION_TOP_VERTICAL_LEFT)
+        );
+        assertEquals(
+                R.layout.tb_taskbar_right,
+                callGetTaskbarLayoutId(POSITION_TOP_RIGHT)
+        );
+        assertEquals(
+                R.layout.tb_taskbar_top_vertical,
+                callGetTaskbarLayoutId(POSITION_TOP_VERTICAL_RIGHT)
+        );
+        assertEquals(
+                R.layout.tb_taskbar_left,
+                callGetTaskbarLayoutId("unsupported")
+        );
+    }
+
+    private int callGetTaskbarLayoutId(String taskbarPosition) {
+        return callInstanceMethod(
+                uiController,
+                "getTaskbarLayoutId",
+                from(String.class, taskbarPosition)
+        );
+    }
+
+    private int callGetTaskbarGravity(String taskbarPosition) {
+        return callInstanceMethod(
+                uiController,
+                "getTaskbarGravity",
+                from(String.class, taskbarPosition)
+        );
     }
 
     private void callDrawStartButton(Context context,

--- a/app/src/test/java/com/farmerbb/taskbar/ui/TaskbarControllerTest.java
+++ b/app/src/test/java/com/farmerbb/taskbar/ui/TaskbarControllerTest.java
@@ -1,0 +1,114 @@
+package com.farmerbb.taskbar.ui;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.graphics.Color;
+import android.widget.ImageView;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import com.farmerbb.taskbar.R;
+import com.farmerbb.taskbar.util.U;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.rule.PowerMockRule;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.android.controller.ServiceController;
+
+import static com.farmerbb.taskbar.util.Constants.PREF_START_BUTTON_IMAGE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.powermock.api.mockito.PowerMockito.when;
+import static org.robolectric.util.ReflectionHelpers.ClassParameter.from;
+import static org.robolectric.util.ReflectionHelpers.callInstanceMethod;
+
+@RunWith(RobolectricTestRunner.class)
+@PowerMockIgnore({"org.mockito.*", "org.robolectric.*", "android.*", "androidx.*"})
+@PrepareForTest(U.class)
+public class TaskbarControllerTest {
+    @Rule
+    public PowerMockRule rule = new PowerMockRule();
+
+    private ServiceController<TaskbarUIHostService> controller;
+    private TaskbarUIHostService hostService;
+    private TaskbarController uiController;
+    private Context context;
+    SharedPreferences prefs;
+
+    @Before
+    public void setUp() {
+        controller = Robolectric.buildService(TaskbarUIHostService.class);
+        hostService = controller.create().get();
+        uiController = hostService.controller;
+        context = ApplicationProvider.getApplicationContext();
+        prefs = U.getSharedPreferences(context);
+    }
+
+    @After
+    public void tearDown() {
+        prefs.edit().remove(PREF_START_BUTTON_IMAGE).apply();
+    }
+
+    @Test
+    public void testInitialization() {
+        assertNotNull(uiController);
+    }
+
+    @Test
+    public void testDrawStartButtonPadding() {
+        ImageView startButton = new ImageView(context);
+        prefs = U.getSharedPreferences(context);
+        prefs.edit().putString(PREF_START_BUTTON_IMAGE, "default").apply();
+        callDrawStartButton(context, startButton, prefs);
+        int padding =
+                context.getResources().getDimensionPixelSize(R.dimen.tb_app_drawer_icon_padding);
+        checkStartButtonPadding(padding, startButton);
+
+        PowerMockito.spy(U.class);
+        // Use bliss os logic to avoid using LauncherApps, that robolectric doesn't support
+        when(U.isBlissOs(context)).thenReturn(true);
+        prefs.edit().putString(PREF_START_BUTTON_IMAGE, "app_logo").apply();
+        callDrawStartButton(context, startButton, prefs);
+        padding =
+                context.getResources().getDimensionPixelSize(R.dimen.tb_app_drawer_icon_padding_alt);
+        checkStartButtonPadding(padding, startButton);
+
+        prefs.edit().putString(PREF_START_BUTTON_IMAGE, "custom").apply();
+        callDrawStartButton(context, startButton, prefs);
+        padding = context.getResources().getDimensionPixelSize(R.dimen.tb_app_drawer_icon_padding);
+        checkStartButtonPadding(padding, startButton);
+
+        prefs.edit().putString(PREF_START_BUTTON_IMAGE, "non-support").apply();
+        callDrawStartButton(context, startButton, prefs);
+        checkStartButtonPadding(0, startButton);
+    }
+
+    private void callDrawStartButton(Context context,
+                                     ImageView startButton,
+                                     SharedPreferences prefs) {
+        callInstanceMethod(
+                uiController,
+                "drawStartButton",
+                from(Context.class, context),
+                from(ImageView.class, startButton),
+                from(SharedPreferences.class, prefs),
+                from(int.class, Color.RED)
+        );
+    }
+
+
+    private void checkStartButtonPadding(int padding, ImageView startButton) {
+        assertEquals(padding, startButton.getPaddingLeft());
+        assertEquals(padding, startButton.getPaddingTop());
+        assertEquals(padding, startButton.getPaddingRight());
+        assertEquals(padding, startButton.getPaddingBottom());
+    }
+}

--- a/app/src/test/java/com/farmerbb/taskbar/ui/TaskbarUIHostService.java
+++ b/app/src/test/java/com/farmerbb/taskbar/ui/TaskbarUIHostService.java
@@ -1,0 +1,15 @@
+package com.farmerbb.taskbar.ui;
+
+import androidx.test.core.app.ApplicationProvider;
+
+public class TaskbarUIHostService extends UIHostService {
+    TaskbarController controller;
+
+    @Override
+    public UIController newController() {
+        if (controller == null) {
+            controller = new TaskbarController(ApplicationProvider.getApplicationContext());
+        }
+        return controller;
+    }
+}


### PR DESCRIPTION
Extract methods to initialize start button and taskbar layout in `TaskbarController` to reduce the size of method `drawTaskbar`.

Test: `./gradlew test`