### PR TITLE
 Split TaskbarController large methods part06

### DIFF
--- a/app/src/main/java/com/farmerbb/taskbar/ui/TaskbarController.java
+++ b/app/src/main/java/com/farmerbb/taskbar/ui/TaskbarController.java
@@ -942,30 +942,7 @@ public class TaskbarController extends UIController {
                 currentTaskbarIds = finalApplicationIds;
                 numOfPinnedApps = realNumOfPinnedApps;
 
-                UserManager userManager = (UserManager) context.getSystemService(Context.USER_SERVICE);
-
-                int launcherAppCachePos = -1;
-                for(int i = 0; i < entries.size(); i++) {
-                    if(entries.get(i).getComponentName() == null) {
-                        launcherAppCachePos++;
-                        LauncherActivityInfo appInfo = launcherAppCache.get(launcherAppCachePos);
-                        String packageName = entries.get(i).getPackageName();
-                        long lastTimeUsed = entries.get(i).getLastTimeUsed();
-
-                        entries.remove(i);
-
-                        AppEntry newEntry = new AppEntry(
-                                packageName,
-                                appInfo.getComponentName().flattenToString(),
-                                appInfo.getLabel().toString(),
-                                IconCache.getInstance(context).getIcon(context, pm, appInfo),
-                                false);
-
-                        newEntry.setUserId(userManager.getSerialNumberForUser(appInfo.getUser()));
-                        newEntry.setLastTimeUsed(lastTimeUsed);
-                        entries.add(i, newEntry);
-                    }
-                }
+                populateAppEntry(context, pm, entries, launcherAppCache);
 
                 final int numOfEntries = Math.min(entries.size(), maxNumOfEntries);
 
@@ -1190,6 +1167,37 @@ public class TaskbarController extends UIController {
             realNumOfPinnedApps = realNumOfPinnedApps + pinnedApps.size();
         }
         return realNumOfPinnedApps;
+    }
+
+    @VisibleForTesting
+    public void populateAppEntry(Context context,
+                                 PackageManager pm,
+                                 List<AppEntry> entries,
+                                 List<LauncherActivityInfo> launcherAppCache) {
+        UserManager userManager = (UserManager) context.getSystemService(Context.USER_SERVICE);
+
+        int launcherAppCachePos = -1;
+        for(int i = 0; i < entries.size(); i++) {
+            if(entries.get(i).getComponentName() == null) {
+                launcherAppCachePos++;
+                LauncherActivityInfo appInfo = launcherAppCache.get(launcherAppCachePos);
+                String packageName = entries.get(i).getPackageName();
+                long lastTimeUsed = entries.get(i).getLastTimeUsed();
+
+                entries.remove(i);
+
+                AppEntry newEntry = new AppEntry(
+                        packageName,
+                        appInfo.getComponentName().flattenToString(),
+                        appInfo.getLabel().toString(),
+                        IconCache.getInstance(context).getIcon(context, pm, appInfo),
+                        false);
+
+                newEntry.setUserId(userManager.getSerialNumberForUser(appInfo.getUser()));
+                newEntry.setLastTimeUsed(lastTimeUsed);
+                entries.add(i, newEntry);
+            }
+        }
     }
 
     private void updateRunningAppIndicators(List<AppEntry> pinnedApps, List<AppEntry> usageStatsList, List<AppEntry> entries) {

--- a/app/src/main/java/com/farmerbb/taskbar/ui/TaskbarController.java
+++ b/app/src/main/java/com/farmerbb/taskbar/ui/TaskbarController.java
@@ -382,7 +382,7 @@ public class TaskbarController extends UIController {
 
     @SuppressLint("RtlHardcoded")
     @VisibleForTesting
-    public int getTaskbarGravity(String taskbarPosition) {
+    int getTaskbarGravity(String taskbarPosition) {
         int gravity = Gravity.BOTTOM | Gravity.LEFT;
         switch(taskbarPosition) {
             case POSITION_BOTTOM_LEFT:
@@ -406,7 +406,7 @@ public class TaskbarController extends UIController {
     }
 
     @VisibleForTesting
-    public int getTaskbarLayoutId(String taskbarPosition) {
+    int getTaskbarLayoutId(String taskbarPosition) {
         int layoutId = R.layout.tb_taskbar_left;
         switch(taskbarPosition) {
             case POSITION_BOTTOM_LEFT:
@@ -430,7 +430,7 @@ public class TaskbarController extends UIController {
     }
 
     @VisibleForTesting
-    public void drawStartButton(Context context, ImageView startButton, SharedPreferences pref, int accentColor) {
+    void drawStartButton(Context context, ImageView startButton, SharedPreferences pref, int accentColor) {
         Drawable allAppsIcon = ContextCompat.getDrawable(context, R.drawable.tb_all_apps_button_icon);
         int padding = 0;
 
@@ -477,10 +477,10 @@ public class TaskbarController extends UIController {
     }
 
     @VisibleForTesting
-    public boolean drawDashboardButton(Context context,
-                                       LinearLayout layout,
-                                       FrameLayout dashboardButton,
-                                       int accentColor) {
+    boolean drawDashboardButton(Context context,
+                                LinearLayout layout,
+                                FrameLayout dashboardButton,
+                                int accentColor) {
         boolean dashboardEnabled = U.getBooleanPrefWithDefault(context, PREF_DASHBOARD);
         if(dashboardEnabled) {
             layout.findViewById(R.id.square1).setBackgroundColor(accentColor);
@@ -499,10 +499,10 @@ public class TaskbarController extends UIController {
     }
 
     @VisibleForTesting
-    public boolean drawNavbarButtons(Context context,
-                                     LinearLayout layout,
-                                     SharedPreferences pref,
-                                     int accentColor) {
+    boolean drawNavbarButtons(Context context,
+                              LinearLayout layout,
+                              SharedPreferences pref,
+                              int accentColor) {
         boolean navbarButtonsEnabled = false;
         if(pref.getBoolean(PREF_BUTTON_BACK, false)) {
             navbarButtonsEnabled = true;
@@ -618,7 +618,7 @@ public class TaskbarController extends UIController {
     }
 
     @VisibleForTesting
-    public long getSearchInterval(SharedPreferences pref) {
+    long getSearchInterval(SharedPreferences pref) {
         long searchInterval = -1;
         switch(pref.getString(PREF_RECENTS_AMOUNT, PREF_RECENTS_AMOUNT_PAST_DAY)) {
             case PREF_RECENTS_AMOUNT_PAST_DAY:
@@ -637,7 +637,7 @@ public class TaskbarController extends UIController {
     }
 
     @VisibleForTesting
-    public void drawSysTray(Context context, int layoutId, LinearLayout layout) {
+    void drawSysTray(Context context, int layoutId, LinearLayout layout) {
         sysTrayLayout = (LinearLayout) LayoutInflater.from(context).inflate(R.layout.tb_system_tray, null);
 
         FrameLayout.LayoutParams sysTrayParams = new FrameLayout.LayoutParams(
@@ -995,11 +995,11 @@ public class TaskbarController extends UIController {
     }
 
     @VisibleForTesting
-    public void calculateScrollViewParams(Context context,
-                                          SharedPreferences pref,
-                                          ViewGroup.LayoutParams params,
-                                          boolean fullLength,
-                                          int numOfEntries) {
+    void calculateScrollViewParams(Context context,
+                                   SharedPreferences pref,
+                                   ViewGroup.LayoutParams params,
+                                   boolean fullLength,
+                                   int numOfEntries) {
         DisplayInfo display = U.getDisplayInfo(context, true);
         int recentsSize =
                 context.getResources().getDimensionPixelSize(R.dimen.tb_icon_size) * numOfEntries;
@@ -1073,11 +1073,11 @@ public class TaskbarController extends UIController {
     }
 
     @VisibleForTesting
-    public void scrollTaskbar(FrameLayout scrollView,
-                              LinearLayout taskbar,
-                              String taskbarPosition,
-                              String sortOrder,
-                              boolean shouldRefreshRecents) {
+    void scrollTaskbar(FrameLayout scrollView,
+                       LinearLayout taskbar,
+                       String taskbarPosition,
+                       String sortOrder,
+                       boolean shouldRefreshRecents) {
         if (TaskbarPosition.isVertical(taskbarPosition)) {
             if (sortOrder.contains("false")) {
                 scrollView.scrollTo(taskbar.getWidth(), taskbar.getHeight());
@@ -1098,10 +1098,10 @@ public class TaskbarController extends UIController {
     }
 
     @VisibleForTesting
-    public void filterForegroundApp(Context context,
-                                    SharedPreferences pref,
-                                    long searchInterval,
-                                    List<String> applicationIdsToRemove) {
+    void filterForegroundApp(Context context,
+                             SharedPreferences pref,
+                             long searchInterval,
+                             List<String> applicationIdsToRemove) {
         if (pref.getBoolean(PREF_HIDE_FOREGROUND, false)) {
             UsageStatsManager mUsageStatsManager =
                     (UsageStatsManager) context.getSystemService(Context.USAGE_STATS_SERVICE);
@@ -1132,7 +1132,7 @@ public class TaskbarController extends UIController {
     }
 
     @VisibleForTesting
-    public boolean needToReverseOrder(Context context, String sortOrder) {
+    boolean needToReverseOrder(Context context, String sortOrder) {
         switch(TaskbarPosition.getTaskbarPosition(context)) {
             case POSITION_BOTTOM_RIGHT:
             case POSITION_TOP_RIGHT:
@@ -1143,10 +1143,10 @@ public class TaskbarController extends UIController {
     }
 
     @VisibleForTesting
-    public int filterRealPinnedApps(Context context,
-                                    List<AppEntry> pinnedApps,
-                                    List<AppEntry> entries,
-                                    List<String> applicationIdsToRemove) {
+    int filterRealPinnedApps(Context context,
+                             List<AppEntry> pinnedApps,
+                             List<AppEntry> entries,
+                             List<String> applicationIdsToRemove) {
         int realNumOfPinnedApps = 0;
         if(pinnedApps.size() > 0) {
             UserManager userManager = (UserManager) context.getSystemService(Context.USER_SERVICE);
@@ -1170,10 +1170,10 @@ public class TaskbarController extends UIController {
     }
 
     @VisibleForTesting
-    public void populateAppEntry(Context context,
-                                 PackageManager pm,
-                                 List<AppEntry> entries,
-                                 List<LauncherActivityInfo> launcherAppCache) {
+    void populateAppEntry(Context context,
+                          PackageManager pm,
+                          List<AppEntry> entries,
+                          List<LauncherActivityInfo> launcherAppCache) {
         UserManager userManager = (UserManager) context.getSystemService(Context.USER_SERVICE);
 
         int launcherAppCachePos = -1;

--- a/app/src/test/java/com/farmerbb/taskbar/shadow/TaskbarShadowLauncherApps.java
+++ b/app/src/test/java/com/farmerbb/taskbar/shadow/TaskbarShadowLauncherApps.java
@@ -1,0 +1,37 @@
+package com.farmerbb.taskbar.shadow;
+
+import android.content.pm.LauncherApps;
+import android.os.UserHandle;
+
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+import org.robolectric.shadows.ShadowLauncherApps;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static android.os.Build.VERSION_CODES.LOLLIPOP;
+
+@Implements(value = LauncherApps.class, minSdk = LOLLIPOP)
+public class TaskbarShadowLauncherApps extends ShadowLauncherApps {
+    private static final List<String> enabledPackages = new ArrayList<>();
+
+    public static void addEnabledPackages(String packageName) {
+        if (!enabledPackages.contains(packageName)) {
+            enabledPackages.add(packageName);
+        }
+    }
+
+    public static void removeEnabledPackage(String packageName) {
+        enabledPackages.remove(packageName);
+    }
+
+    public static void reset() {
+        enabledPackages.clear();
+    }
+
+    @Implementation
+    protected boolean isPackageEnabled(String packageName, UserHandle user) {
+        return enabledPackages.contains(packageName);
+    }
+}

--- a/app/src/test/java/com/farmerbb/taskbar/shadow/TaskbarShadowScrollView.java
+++ b/app/src/test/java/com/farmerbb/taskbar/shadow/TaskbarShadowScrollView.java
@@ -1,4 +1,4 @@
-package com.farmerbb.taskbar.ui;
+package com.farmerbb.taskbar.shadow;
 
 import android.widget.ScrollView;
 

--- a/app/src/test/java/com/farmerbb/taskbar/ui/TaskbarControllerTest.java
+++ b/app/src/test/java/com/farmerbb/taskbar/ui/TaskbarControllerTest.java
@@ -5,10 +5,14 @@ import android.app.usage.UsageEvents;
 import android.app.usage.UsageStatsManager;
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.content.pm.ActivityInfo;
+import android.content.pm.LauncherActivityInfo;
+import android.content.pm.PackageManager;
 import android.graphics.Color;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import android.os.SystemClock;
+import android.os.UserHandle;
 import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -75,15 +79,18 @@ import static com.farmerbb.taskbar.util.Constants.PREF_TIME_OF_SERVICE_START;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.powermock.api.mockito.PowerMockito.when;
 import static org.robolectric.Shadows.shadowOf;
+import static org.robolectric.util.ReflectionHelpers.ClassParameter.from;
 
 @RunWith(RobolectricTestRunner.class)
 @PowerMockIgnore({"org.mockito.*", "org.robolectric.*",
         "android.*", "androidx.*", "com.farmerbb.taskbar.shadow.*"})
 @PrepareForTest(value = {U.class, TaskbarPosition.class})
 public class TaskbarControllerTest {
+    private static final int DEFAULT_TEST_USER_ID = 0;
     @Rule
     public PowerMockRule rule = new PowerMockRule();
 
@@ -627,6 +634,51 @@ public class TaskbarControllerTest {
         assertEquals(1, entries.size());
     }
 
+    @Test
+    public void testPopulateAppEntry() {
+        List<AppEntry> entries = new ArrayList<>();
+        PackageManager pm = context.getPackageManager();
+        List<LauncherActivityInfo> launcherAppCache = new ArrayList<>();
+
+        uiController.populateAppEntry(context, pm, entries, launcherAppCache);
+        assertEquals(0, entries.size());
+
+        AppEntry appEntry = generateTestAppEntry(1);
+        entries.add(appEntry);
+        uiController.populateAppEntry(context, pm, entries, launcherAppCache);
+        assertEquals(1, entries.size());
+        assertSame(appEntry, entries.get(0));
+
+        AppEntry firstEntry = appEntry;
+        appEntry = new AppEntry("test-package", null, null, null, false);
+        appEntry.setLastTimeUsed(System.currentTimeMillis());
+        entries.add(appEntry);
+        ActivityInfo info = new ActivityInfo();
+        info.packageName = appEntry.getPackageName();
+        info.name = "test-name";
+        info.nonLocalizedLabel = "test-label";
+        LauncherActivityInfo launcherActivityInfo =
+                ReflectionHelpers.callConstructor(
+                        LauncherActivityInfo.class,
+                        from(Context.class, context),
+                        from(ActivityInfo.class, info),
+                        from(UserHandle.class, UserHandle.getUserHandleForUid(DEFAULT_TEST_USER_ID))
+                );
+        launcherAppCache.add(launcherActivityInfo);
+        uiController.populateAppEntry(context, pm, entries, launcherAppCache);
+        assertEquals(2, entries.size());
+        assertSame(firstEntry, entries.get(0));
+        AppEntry populatedEntry = entries.get(1);
+        assertEquals(info.packageName, populatedEntry.getPackageName());
+        assertEquals(
+                launcherActivityInfo.getComponentName().flattenToString(),
+                populatedEntry.getComponentName()
+        );
+        assertEquals(info.nonLocalizedLabel.toString(), populatedEntry.getLabel());
+        assertEquals(DEFAULT_TEST_USER_ID, populatedEntry.getUserId(context));
+        assertEquals(appEntry.getLastTimeUsed(), populatedEntry.getLastTimeUsed());
+    }
+
     private AppEntry generateTestAppEntry(int index) {
         AppEntry appEntry =
                 new AppEntry(
@@ -636,7 +688,7 @@ public class TaskbarControllerTest {
                         null,
                         false
                 );
-        appEntry.setUserId(0);
+        appEntry.setUserId(DEFAULT_TEST_USER_ID);
         return appEntry;
     }
 


### PR DESCRIPTION
1. Extract method to filter real pinned apps in `TaskbarController`.
2. Extract method to populate final app entry in `TaskbarController`.
3. Remove unused public modifier for `@VisibleForTesting` methods.

`Robolectric` doesn't support `LauncherApps.isPackageEnabled` in this shadow
implementation, so we should add a new implementation to support it. And
we should ignore custom shadows from `powermock` to avoid the problem
that the `classloader` of custom shadow isn't equals to `classloader`
used by `robolectric`. For example, if we don't ignore custom shadow from
`powermock`, the following casting can't be executed:

```java
TaskbarShadowLauncherApps shadowLauncherApps = Shadows.shadowOf(launcherApps);
```

Test: `./gradlew test`