### PR TITLE
Split TaskbarController large methods part07

### DIFF
--- a/app/src/test/java/com/farmerbb/taskbar/shadow/TaskbarShadowLauncherApps.java
+++ b/app/src/test/java/com/farmerbb/taskbar/shadow/TaskbarShadowLauncherApps.java
@@ -1,5 +1,6 @@
 package com.farmerbb.taskbar.shadow;
 
+import android.content.pm.LauncherActivityInfo;
 import android.content.pm.LauncherApps;
 import android.os.UserHandle;
 
@@ -8,15 +9,19 @@ import org.robolectric.annotation.Implements;
 import org.robolectric.shadows.ShadowLauncherApps;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import static android.os.Build.VERSION_CODES.LOLLIPOP;
 
 @Implements(value = LauncherApps.class, minSdk = LOLLIPOP)
 public class TaskbarShadowLauncherApps extends ShadowLauncherApps {
     private Map<UserHandle, List<String>> enabledPackages = new HashMap<>();
+    private Map<UserHandle, List<LauncherActivityInfo>> activityList = new HashMap<>();
 
     public void reset() {
         enabledPackages.clear();
@@ -39,9 +44,38 @@ public class TaskbarShadowLauncherApps extends ShadowLauncherApps {
         enabledPackages.put(userHandle, packages);
     }
 
+    /**
+     * Add an {@link LauncherActivityInfo} to be got by {@link #getActivityList(String, UserHandle)}.
+     *
+     * @param userHandle   the user handle to be added.
+     * @param activityInfo the {@link LauncherActivityInfo} to be added.
+     */
+    public void addActivity(UserHandle userHandle, LauncherActivityInfo activityInfo) {
+        List<LauncherActivityInfo> activityInfoList = activityList.get(userHandle);
+        if (activityInfoList == null) {
+            activityInfoList = new ArrayList<>();
+        }
+        activityInfoList.remove(activityInfo);
+        activityInfoList.add(activityInfo);
+        activityList.put(userHandle, activityInfoList);
+    }
+
     @Implementation
     protected boolean isPackageEnabled(String packageName, UserHandle user) {
         List<String> packages = enabledPackages.get(user);
         return packages != null && packages.contains(packageName);
+    }
+
+    @Implementation
+    public List<LauncherActivityInfo> getActivityList(String packageName, UserHandle user) {
+        List<LauncherActivityInfo> activityInfoList = activityList.get(user);
+        if (activityInfoList == null || packageName == null) {
+            return Collections.emptyList();
+        }
+        final Predicate<LauncherActivityInfo> predicatePackage =
+                info ->
+                        info.getComponentName() != null
+                                && packageName.equals(info.getComponentName().getPackageName());
+        return activityInfoList.stream().filter(predicatePackage).collect(Collectors.toList());
     }
 }

--- a/app/src/test/java/com/farmerbb/taskbar/shadow/TaskbarShadowLauncherApps.java
+++ b/app/src/test/java/com/farmerbb/taskbar/shadow/TaskbarShadowLauncherApps.java
@@ -8,30 +8,40 @@ import org.robolectric.annotation.Implements;
 import org.robolectric.shadows.ShadowLauncherApps;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static android.os.Build.VERSION_CODES.LOLLIPOP;
 
 @Implements(value = LauncherApps.class, minSdk = LOLLIPOP)
 public class TaskbarShadowLauncherApps extends ShadowLauncherApps {
-    private static final List<String> enabledPackages = new ArrayList<>();
+    private Map<UserHandle, List<String>> enabledPackages = new HashMap<>();
 
-    public static void addEnabledPackages(String packageName) {
-        if (!enabledPackages.contains(packageName)) {
-            enabledPackages.add(packageName);
-        }
-    }
-
-    public static void removeEnabledPackage(String packageName) {
-        enabledPackages.remove(packageName);
-    }
-
-    public static void reset() {
+    public void reset() {
         enabledPackages.clear();
+    }
+
+    /**
+     * Adds an enabled package to be checked by {@link #isPackageEnabled(String, UserHandle)}.
+     *
+     * @param userHandle  the user handle to be added.
+     * @param packageName the package name to be added.
+     */
+    public void addEnabledPackage(UserHandle userHandle, String packageName) {
+        List<String> packages = enabledPackages.get(userHandle);
+        if (packages == null) {
+            packages = new ArrayList<>();
+        }
+        if (!packages.contains(packageName)) {
+            packages.add(packageName);
+        }
+        enabledPackages.put(userHandle, packages);
     }
 
     @Implementation
     protected boolean isPackageEnabled(String packageName, UserHandle user) {
-        return enabledPackages.contains(packageName);
+        List<String> packages = enabledPackages.get(user);
+        return packages != null && packages.contains(packageName);
     }
 }

--- a/app/src/test/java/com/farmerbb/taskbar/ui/TaskbarControllerTest.java
+++ b/app/src/test/java/com/farmerbb/taskbar/ui/TaskbarControllerTest.java
@@ -93,6 +93,12 @@ import static org.robolectric.util.ReflectionHelpers.ClassParameter.from;
         "android.*", "androidx.*", "com.farmerbb.taskbar.shadow.*"})
 @PrepareForTest(value = {U.class, TaskbarPosition.class})
 public class TaskbarControllerTest {
+    private static final String UNSUPPORTED = "unsupported";
+    private static final String ENTRY_TEST_PACKAGE = "test-package";
+    private static final String ENTRY_TEST_COMPONENT = "test-component";
+    private static final String ENTRY_TEST_LABEL = "test-label";
+    private static final String ENTRY_TEST_NAME = "test-name";
+
     private static final int DEFAULT_TEST_USER_ID = 0;
     private static final int DEFAULT_TEST_USER_PROFILE_ID = 200000;
     @Rule
@@ -190,7 +196,7 @@ public class TaskbarControllerTest {
         );
         assertEquals(
                 Gravity.BOTTOM | Gravity.LEFT,
-                uiController.getTaskbarGravity("unsupported")
+                uiController.getTaskbarGravity(UNSUPPORTED)
         );
     }
 
@@ -230,7 +236,7 @@ public class TaskbarControllerTest {
         );
         assertEquals(
                 R.layout.tb_taskbar_left,
-                uiController.getTaskbarLayoutId("unsupported")
+                uiController.getTaskbarLayoutId(UNSUPPORTED)
         );
     }
 
@@ -345,7 +351,7 @@ public class TaskbarControllerTest {
         searchInterval = uiController.getSearchInterval(prefs);
         assertEquals(-1, searchInterval);
 
-        prefs.edit().putString(PREF_RECENTS_AMOUNT, "unsupported").apply();
+        prefs.edit().putString(PREF_RECENTS_AMOUNT, UNSUPPORTED).apply();
         searchInterval = uiController.getSearchInterval(prefs);
         assertEquals(-1, searchInterval);
 
@@ -502,27 +508,28 @@ public class TaskbarControllerTest {
         List<String> applicationIdsToRemove = new ArrayList<>();
         UsageStatsManager usageStatsManager =
                 (UsageStatsManager) context.getSystemService(Context.USAGE_STATS_SERVICE);
+        final String entryTestPackage1 = ENTRY_TEST_PACKAGE + "-1";
         UsageEvents.Event event =
                 EventBuilder
                         .buildEvent()
                         .setEventType(MOVE_TO_FOREGROUND)
                         .setTimeStamp(100L)
-                        .setPackage("test-package-1")
+                        .setPackage(entryTestPackage1)
                         .build();
         shadowOf(usageStatsManager).addEvent(event);
         uiController.filterForegroundApp(context, prefs, searchInterval, applicationIdsToRemove);
-        assertEquals("test-package-1", applicationIdsToRemove.remove(0));
+        assertEquals(entryTestPackage1, applicationIdsToRemove.remove(0));
 
         event =
                 EventBuilder
                         .buildEvent()
                         .setEventType(MOVE_TO_BACKGROUND)
                         .setTimeStamp(200L)
-                        .setPackage("test-package-2")
+                        .setPackage(ENTRY_TEST_PACKAGE + "-2")
                         .build();
         shadowOf(usageStatsManager).addEvent(event);
         uiController.filterForegroundApp(context, prefs, searchInterval, applicationIdsToRemove);
-        assertEquals("test-package-1", applicationIdsToRemove.remove(0));
+        assertEquals(entryTestPackage1, applicationIdsToRemove.remove(0));
 
         event = buildTaskbarForegroundAppEvent(MainActivity.class.getCanonicalName(), 300L);
         shadowOf(usageStatsManager).addEvent(event);
@@ -549,10 +556,10 @@ public class TaskbarControllerTest {
         uiController.filterForegroundApp(context, prefs, searchInterval, applicationIdsToRemove);
         assertEquals(InvisibleActivityFreeform.class.getCanonicalName(), applicationIdsToRemove.remove(0));
 
-        event = buildTaskbarForegroundAppEvent("unsupported", 800L);
+        event = buildTaskbarForegroundAppEvent(UNSUPPORTED, 800L);
         shadowOf(usageStatsManager).addEvent(event);
         uiController.filterForegroundApp(context, prefs, searchInterval, applicationIdsToRemove);
-        assertEquals("unsupported", applicationIdsToRemove.remove(0));
+        assertEquals(UNSUPPORTED, applicationIdsToRemove.remove(0));
 
         prefs.edit().remove(PREF_HIDE_FOREGROUND).apply();
         uiController.filterForegroundApp(context, prefs, searchInterval, applicationIdsToRemove);
@@ -574,7 +581,7 @@ public class TaskbarControllerTest {
         positions.add(POSITION_TOP_RIGHT);
         positions.add(POSITION_TOP_VERTICAL_LEFT);
         positions.add(POSITION_TOP_VERTICAL_RIGHT);
-        positions.add("unsupported");
+        positions.add(UNSUPPORTED);
 
         String sortOrder = "false";
         for (String position : positions) {
@@ -596,7 +603,7 @@ public class TaskbarControllerTest {
             }
         }
 
-        sortOrder = "unsupported";
+        sortOrder = UNSUPPORTED;
         for (String position : positions) {
             positionAnswer.answer = position;
             assertFalse(uiController.needToReverseOrder(context, sortOrder));
@@ -725,8 +732,8 @@ public class TaskbarControllerTest {
         appEntry =
                 new AppEntry(
                         "com.google.android.googlequicksearchbox",
-                        "test-component",
-                        "test-label",
+                        ENTRY_TEST_COMPONENT,
+                        ENTRY_TEST_LABEL,
                         null,
                         false
                 );
@@ -770,13 +777,13 @@ public class TaskbarControllerTest {
         assertSame(appEntry, entries.get(0));
 
         AppEntry firstEntry = appEntry;
-        appEntry = new AppEntry("test-package", null, null, null, false);
+        appEntry = new AppEntry(ENTRY_TEST_PACKAGE, null, null, null, false);
         appEntry.setLastTimeUsed(System.currentTimeMillis());
         entries.add(appEntry);
         ActivityInfo info = new ActivityInfo();
         info.packageName = appEntry.getPackageName();
-        info.name = "test-name";
-        info.nonLocalizedLabel = "test-label";
+        info.name = ENTRY_TEST_NAME;
+        info.nonLocalizedLabel = ENTRY_TEST_LABEL;
         LauncherActivityInfo launcherActivityInfo =
                 generateTestLauncherActivityInfo(context, info, DEFAULT_TEST_USER_ID);
         launcherAppCache.add(launcherActivityInfo);
@@ -809,9 +816,9 @@ public class TaskbarControllerTest {
     private AppEntry generateTestAppEntry(int index) {
         AppEntry appEntry =
                 new AppEntry(
-                        "test-package-" + index,
-                        "test-component" + index,
-                        "test-label-" + index,
+                        ENTRY_TEST_PACKAGE + "-" + index,
+                        ENTRY_TEST_COMPONENT + "-" + index,
+                        ENTRY_TEST_LABEL + "-" + index,
                         null,
                         false
                 );


### PR DESCRIPTION
1.  Use instance methods to replace static methods in TaskbarShadowLauncherApps.
2.  Extract method to generate app entries for TaskbarController.
3.  Extract raw string to constant in TaskbarControllerTest.

Test: `./gradlew test`