### PR TITLE
 Split DashboardController large methods part03

### DIFF
--- a/app/src/main/java/com/farmerbb/taskbar/ui/DashboardController.java
+++ b/app/src/main/java/com/farmerbb/taskbar/ui/DashboardController.java
@@ -423,10 +423,11 @@ public class DashboardController extends UIController {
 
     @Override
     public void onDestroyHost(UIHost host) {
-        if(layout != null)
+        if (layout != null) {
             try {
                 host.removeView(layout);
             } catch (IllegalArgumentException e) { /* Gracefully fail */ }
+        }
 
         U.unregisterReceiver(context, toggleReceiver);
         U.unregisterReceiver(context, addWidgetReceiver);
@@ -434,11 +435,17 @@ public class DashboardController extends UIController {
         U.unregisterReceiver(context, hideReceiver);
 
         SharedPreferences pref = U.getSharedPreferences(context);
-        if(!LauncherHelper.getInstance().isOnSecondaryHomeScreen(context)
-                || !pref.getBoolean(PREF_DONT_STOP_DASHBOARD, false))
+        if (shouldSendDisappearingBroadcast(context, pref)) {
             U.sendBroadcast(context, ACTION_DASHBOARD_DISAPPEARING);
+        }
 
         pref.edit().remove(PREF_DONT_STOP_DASHBOARD).apply();
+    }
+
+    @VisibleForTesting
+    boolean shouldSendDisappearingBroadcast(Context context, SharedPreferences pref) {
+        return !LauncherHelper.getInstance().isOnSecondaryHomeScreen(context)
+                || !pref.getBoolean(PREF_DONT_STOP_DASHBOARD, false);
     }
 
     private void cellClick(View view, boolean isActualClick) {

--- a/app/src/main/java/com/farmerbb/taskbar/ui/DashboardController.java
+++ b/app/src/main/java/com/farmerbb/taskbar/ui/DashboardController.java
@@ -469,20 +469,8 @@ public class DashboardController extends UIController {
             intent.putExtra(EXTRA_CELL_ID, cellId);
             U.sendBroadcast(context, intent);
 
-            if(shouldShowPlaceholder) {
-                String providerName =
-                        pref.getString(generateProviderPrefKey(cellId), PREF_DEFAULT_NULL);
-                if(!providerName.equals(PREF_DEFAULT_NULL)) {
-                    ComponentName componentName = ComponentName.unflattenFromString(providerName);
-
-                    List<AppWidgetProviderInfo> providerInfoList = appWidgetManager.getInstalledProvidersForProfile(Process.myUserHandle());
-                    for(AppWidgetProviderInfo info : providerInfoList) {
-                        if(info.provider.equals(componentName)) {
-                            U.showToast(context, context.getString(R.string.tb_widget_restore_toast, info.loadLabel(context.getPackageManager())), Toast.LENGTH_SHORT);
-                            break;
-                        }
-                    }
-                }
+            if (shouldShowPlaceholder) {
+                showPlaceholderToast(context, appWidgetManager, cellId, pref);
             }
 
             previouslySelectedCell = -1;
@@ -504,6 +492,31 @@ public class DashboardController extends UIController {
     @VisibleForTesting
     String generateProviderPlaceholderPrefKey(int cellId) {
         return PREF_DASHBOARD_WIDGET_PREFIX + cellId + PREF_DASHBOARD_WIDGET_PLACEHOLDER_SUFFIX;
+    }
+
+    @VisibleForTesting
+    void showPlaceholderToast(Context context,
+                              AppWidgetManager appWidgetManager,
+                              int cellId,
+                              SharedPreferences pref) {
+        String providerName = pref.getString(generateProviderPrefKey(cellId), PREF_DEFAULT_NULL);
+        if (providerName != null && !PREF_DEFAULT_NULL.equals(providerName)) {
+            ComponentName componentName = ComponentName.unflattenFromString(providerName);
+
+            List<AppWidgetProviderInfo> providerInfoList =
+                    appWidgetManager.getInstalledProvidersForProfile(Process.myUserHandle());
+            for (AppWidgetProviderInfo info : providerInfoList) {
+                if (info.provider.equals(componentName)) {
+                    String text =
+                            context.getString(
+                                    R.string.tb_widget_restore_toast,
+                                    info.loadLabel(context.getPackageManager())
+                            );
+                    U.showToast(context, text, Toast.LENGTH_SHORT);
+                    break;
+                }
+            }
+        }
     }
 
     private void cellLongClick(View view) {

--- a/app/src/test/java/com/farmerbb/taskbar/shadow/TaskbarShadowAppWidgetManager.java
+++ b/app/src/test/java/com/farmerbb/taskbar/shadow/TaskbarShadowAppWidgetManager.java
@@ -1,0 +1,31 @@
+package com.farmerbb.taskbar.shadow;
+
+import android.appwidget.AppWidgetManager;
+import android.appwidget.AppWidgetProviderInfo;
+import android.os.UserHandle;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+import org.robolectric.shadows.ShadowAppWidgetManager;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Implements(AppWidgetManager.class)
+public class TaskbarShadowAppWidgetManager extends ShadowAppWidgetManager {
+    private Multimap<UserHandle, AppWidgetProviderInfo> installedProvidersForProfile =
+            HashMultimap.create();
+
+    public void addInstalledProvidersForProfile(UserHandle userHandle,
+                                                AppWidgetProviderInfo appWidgetProviderInfo) {
+        installedProvidersForProfile.put(userHandle, appWidgetProviderInfo);
+    }
+
+    @Implementation
+    protected List<AppWidgetProviderInfo> getInstalledProvidersForProfile(UserHandle profile) {
+        return new ArrayList<>(installedProvidersForProfile.get(profile));
+    }
+}

--- a/app/src/test/java/com/farmerbb/taskbar/shadow/TaskbarShadowAppWidgetProviderInfo.java
+++ b/app/src/test/java/com/farmerbb/taskbar/shadow/TaskbarShadowAppWidgetProviderInfo.java
@@ -1,0 +1,17 @@
+package com.farmerbb.taskbar.shadow;
+
+import android.appwidget.AppWidgetProviderInfo;
+import android.content.pm.PackageManager;
+
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+
+@Implements(AppWidgetProviderInfo.class)
+public class TaskbarShadowAppWidgetProviderInfo {
+    public String label = "";
+
+    @Implementation
+    protected final String loadLabel(PackageManager packageManager) {
+        return label;
+    }
+}

--- a/app/src/test/java/com/farmerbb/taskbar/shadow/TaskbarShadowLauncherApps.java
+++ b/app/src/test/java/com/farmerbb/taskbar/shadow/TaskbarShadowLauncherApps.java
@@ -83,7 +83,7 @@ public class TaskbarShadowLauncherApps extends ShadowLauncherApps {
     }
 
     @Implementation
-    public List<LauncherActivityInfo> getActivityList(String packageName, UserHandle user) {
+    protected List<LauncherActivityInfo> getActivityList(String packageName, UserHandle user) {
         List<LauncherActivityInfo> activityInfoList = activityList.get(user);
         if (activityInfoList == null || packageName == null) {
             return Collections.emptyList();


### PR DESCRIPTION
1.  Extract method `DashboardController#shouldSendDisappearingBroadcast`.
2.  Extract method `DashboardController#showPlaceholderToast`. 

Test: `./gradlew test`

I will try to send added shadow to robolectric. The old added `LauncherApps` shadow methods are
merged by robolectric, so when the next robolectric is release, I will upgrade it and delete `Taskbar`
version from code.