### PR TITLE
Remove applicationId placeholder from Android-x86 AndroidManifest.xml

### DIFF
--- a/app/src/androidx86/AndroidManifest.xml
+++ b/app/src/androidx86/AndroidManifest.xml
@@ -437,7 +437,7 @@
 
         <provider
             android:name=".provider.Kustom5SecsProvider"
-            android:authorities="${applicationId}.kustom5secsprovider"
+            android:authorities="com.farmerbb.taskbar.androidx86.kustom5secsprovider"
             android:grantUriPermissions="true"
             android:exported="true"
             android:enabled="true"/>


### PR DESCRIPTION
It will fix Android-x86 building.

Test: test building with Android-x86 pie-x86.