### PR TITLE
Migrate jcenter to mavenCentral

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
 
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         maven { url 'https://jitpack.io' }
     }
 
@@ -23,7 +23,7 @@ dependencyUpdates {
 
 allprojects {
     repositories {
-        jcenter()
+        mavenCentral()
         google()
     }
 }


### PR DESCRIPTION
The JFrog will shutdown jcenter and bintray service, see here:
https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/.

So this CL migrates jcenter to mavenCentral.