### PR TITLE
Add tests for ToastHelper and GlobalHelper

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -144,6 +144,7 @@ dependencies {
     implementation 'moe.banana:toast-compat:1.0.5'
     implementation group:'com.twofortyfouram', name:'android-plugin-api-for-locale', version:'[1.0.2,2.0['
 
+    testImplementation "com.google.truth:truth:1.1.2"
     testImplementation "org.jetbrains.kotlin:kotlin-stdlib:$KOTLIN_VERSION"
     testImplementation 'junit:junit:4.13.1'
     testImplementation 'androidx.test:core:1.3.0'

--- a/app/src/test/java/com/farmerbb/taskbar/helper/GlobalHelperTest.kt
+++ b/app/src/test/java/com/farmerbb/taskbar/helper/GlobalHelperTest.kt
@@ -1,0 +1,68 @@
+package com.farmerbb.taskbar.helper
+
+import android.os.Build.VERSION_CODES.O_MR1
+import android.os.Build.VERSION_CODES.P
+import com.google.common.truth.Truth.assertThat
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+class GlobalHelperTest {
+    private lateinit var globalHelper: GlobalHelper
+    private var defaultIsOnMainActivity: Boolean = false
+
+    @Before
+    fun setUp() {
+        globalHelper = GlobalHelper.getInstance()
+        defaultIsOnMainActivity = globalHelper.isOnMainActivity
+    }
+
+    @After
+    fun tearDown() {
+        globalHelper.isOnMainActivity = defaultIsOnMainActivity
+    }
+
+    @Test
+    fun getInstance_AlwaysBeTheSame() {
+        Assert.assertNotNull(globalHelper)
+        for (i in 1..20) {
+            Assert.assertEquals(globalHelper, GlobalHelper.getInstance())
+        }
+    }
+
+    @Test
+    fun isOnMainActivity_DefaultValueIsFalse() {
+        assertThat(globalHelper.isOnMainActivity).isFalse()
+    }
+
+    @Test
+    fun setOnMainActivity_ShouldChangedToSpecificValue() {
+        val defaultIsOnMainActivity = globalHelper.isOnMainActivity
+        globalHelper.isOnMainActivity = !defaultIsOnMainActivity
+        assertThat(globalHelper.isOnMainActivity).isEqualTo(!defaultIsOnMainActivity)
+    }
+
+    @Test
+    @Config(maxSdk = O_MR1)
+    fun isReflectionAllowed_ShouldTrueDefaultBeforeP() {
+        assertThat(globalHelper.isReflectionAllowed).isTrue()
+    }
+
+    @Test
+    @Config(minSdk = P)
+    fun isReflectionAllowed_ShouldFalseDefaultFromP() {
+        assertThat(globalHelper.isReflectionAllowed).isFalse()
+    }
+
+    @Test
+    fun setReflectionAllowed_ShouldChangedToSpecificValue() {
+        val defaultReflectionAllowed = globalHelper.isReflectionAllowed
+        globalHelper.isReflectionAllowed = !defaultReflectionAllowed
+        assertThat(globalHelper.isReflectionAllowed).isEqualTo(!defaultReflectionAllowed)
+    }
+}

--- a/app/src/test/java/com/farmerbb/taskbar/helper/ToastHelperTest.kt
+++ b/app/src/test/java/com/farmerbb/taskbar/helper/ToastHelperTest.kt
@@ -1,0 +1,58 @@
+package com.farmerbb.taskbar.helper
+
+import com.farmerbb.taskbar.util.ToastInterface
+import com.google.common.truth.Truth.assertThat
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ToastHelperTest {
+    private lateinit var toastHelper: ToastHelper
+    private var lastToast: ToastInterface? = null
+
+    @Before
+    fun setUp() {
+        toastHelper = ToastHelper.getInstance()
+        lastToast = toastHelper.lastToast
+    }
+
+    @After
+    fun tearDown() {
+        toastHelper.lastToast = lastToast
+    }
+
+    @Test
+    fun getInstance_AlwaysBeTheSame() {
+        Assert.assertNotNull(toastHelper)
+        for (i in 1..20) {
+            Assert.assertEquals(toastHelper, ToastHelper.getInstance())
+        }
+    }
+
+    @Test
+    fun getLastToast_DefaultValueIsNull() {
+        assertThat(toastHelper.lastToast).isNull()
+    }
+
+    @Test
+    fun setLastToast_ShouldChangedToSpecificValue() {
+        class ToastInterfaceImpl : ToastInterface {
+            override fun show() {
+                // Do nothing
+            }
+
+            override fun cancel() {
+                // Do nothing
+            }
+        }
+
+        val toastInterface = ToastInterfaceImpl()
+        toastHelper.lastToast = toastInterface
+        assertThat(toastHelper.lastToast).isNotNull()
+        assertThat(toastHelper.lastToast).isEqualTo(toastInterface)
+    }
+}


### PR DESCRIPTION
Add tests for `ToastHelper` and `GlobalHelper`.

There are also some changes for tests:
    
1. Prefer to use `assertThat` from Truth to check value to get more meaningful debug info.
2. Use `yourTestMethod_YourExpectedValue()` as test method name pattern.The old name pattern will be kept, and migrated to the new name pattern with continuous commits.
    
