### PR TITLE
Migrate jcenter to mavenCentral

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,8 @@ buildscript {
 
     repositories {
         google()
-        jcenter()
         mavenCentral()
+        gradlePluginPortal()
         maven { url 'https://jitpack.io' }
     }
 
@@ -25,9 +25,9 @@ dependencyUpdates {
 
 allprojects {
     repositories {
-        jcenter()
         google()
         mavenCentral()
+        gradlePluginPortal()
     }
 }
 


### PR DESCRIPTION
See https://developer.android.com/studio/build/jcenter-migration
and https://stackoverflow.com/questions/49573157/android-studio-3-1-could-not-find-org-jetbrains-trove4jtrove4j20160824.