### PR TITLE
Bump Robolectric to 4.7.3

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -151,7 +151,7 @@ dependencies {
     testImplementation "com.google.truth:truth:1.1.3"
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'androidx.test:core:1.4.0'
-    testImplementation "org.robolectric:robolectric:4.6.1"
+    testImplementation "org.robolectric:robolectric:4.7.3"
     testImplementation "org.powermock:powermock-module-junit4:$POWERMOCK_VERSION"
     testImplementation "org.powermock:powermock-module-junit4-rule:$POWERMOCK_VERSION"
     testImplementation "org.powermock:powermock-api-mockito2:$POWERMOCK_VERSION"


### PR DESCRIPTION
Bump Robolectric to latest 4.7.3.

I don't bump SDK to 31 for Robolectric, because there are some failed tests when running with SDK 31. Looks like there are some API changes from SDK 31, used by tests. When I have time, I will try to fix it.