### PR TITLE
fix ArrayIndexOutOfBoundsException crash

### DIFF
--- a/app/src/main/java/com/farmerbb/taskbar/ui/TaskbarController.java
+++ b/app/src/main/java/com/farmerbb/taskbar/ui/TaskbarController.java
@@ -896,7 +896,7 @@ public class TaskbarController extends UIController {
                 try {
                     entries.remove(entries.size() - 1);
                     launcherAppCache.remove(launcherAppCache.size() - 1);
-                } catch (ArrayIndexOutOfBoundsException ignored) {}
+                } catch (IndexOutOfBoundsException ignored) {}
             }
 
             // Determine if we need to reverse the order again


### PR DESCRIPTION
ArrayIndexOutOfBoundsException isn't broad enough and was causing a crash on some devices. I think it should be replaced with IndexOutOfBoundsException instead.